### PR TITLE
Bug Fix: S3 path becoming a link

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -316,7 +316,6 @@ function linkDefaultSheets() {
             } else {
               // showing the filepicker
               const current = data.actor ? data.actor[dataEditField] : data[dataEditField];
-              const dir = Utils.dirPath(current);
               new FilePicker({
                 type: "image",
                 current,
@@ -326,7 +325,7 @@ function linkDefaultSheets() {
                 },
                 top: app.position.top + 40,
                 left: app.position.left + 10,
-              }).browse(dir);
+              }).browse();
             }
           });
         });


### PR DESCRIPTION
Fix for #157 

When opening Foundry's FilePicker, the target directory for S3 files incorrectly used the root of their full URL instead of their relative location within the bucket.

Removing the target directory does not break anything, as Foundry automatically retrieves the location of the current image.